### PR TITLE
JMAP support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,67 @@
-from debian:8.0
+FROM debian:buster
+ENV DEBIAN_FRONTEND='noninteractive'
+RUN apt update
 
-ENV DEBIAN_FRONTEND noninteractive
+# dependencies
+RUN  apt install -y autoconf automake autotools-dev bash-completion bison build-essential comerr-dev \
+debhelper flex g++ git gperf groff heimdal-dev libbsd-resource-perl libclone-perl libconfig-inifiles-perl \
+libcunit1-dev libdatetime-perl libdb-dev libdigest-sha-perl libencode-imaputf7-perl libfile-chdir-perl \
+libglib2.0-dev libical-dev libio-socket-inet6-perl libio-stringy-perl libjansson-dev libldap2-dev \
+libnet-server-perl libnews-nntpclient-perl libpam0g-dev libpcre3-dev libsasl2-dev \
+libsnmp-dev libsqlite3-dev libssl-dev libtest-unit-perl libtool libunix-syslog-perl liburi-perl \
+libxapian-dev libxml-generator-perl libxml-xpath-perl libxml2-dev libwrap0-dev libzephyr-dev lsb-base \
+net-tools perl php-cli php-curl pkg-config po-debconf tcl-dev \
+transfig uuid-dev vim wamerican wget xutils-dev zlib1g-dev sasl2-bin rsyslog sudo acl telnet rsync \
+libsasl2-modules sasl2-bin libsasl2-modules-gssapi-mit \
+libchardet1 libnghttp2-dev libwslay-dev ssl-cert
 
-RUN apt-get update && apt-get -y upgrade
 
-RUN echo "cyrus-common cyrus-common/removespools boolean true" | debconf-set-selections
+RUN apt-get -y  install libxapian-dev
 
-RUN apt-get -y install cyrus-imapd cyrus-admin sasl2-bin
+# download cyrus
+RUN wget https://github.com/cyrusimap/cyrus-imapd/releases/download/cyrus-imapd-3.2.3/cyrus-imapd-3.2.3.tar.gz
+RUN tar -xzvf cyrus-imapd-3.2.3.tar.gz
 
-RUN mkdir -p /run/cyrus/proc && chown -R cyrus /run/cyrus
+# configure cyrus
+WORKDIR /cyrus-imapd-3.2.3
 
+RUN autoreconf -i -s 
+RUN ./configure --enable-http --enable-jmap --enable-xapian --prefix=/usr/cyrus
+RUN make
+RUN make install
+
+## define conf
 ADD cyrus.conf /etc/cyrus.conf
 ADD imapd.conf /etc/imapd.conf
 
-# create some default use, cyrus is configured as admin in imapd.conf
-RUN echo "cyrus"|saslpasswd2 -u test -c cyrus -p
-RUN echo "bob"|saslpasswd2 -u test -c bob -p
-RUN echo "alice"|saslpasswd2 -u test -c alice -p
+# Setting up  syslog
+RUN echo "local6.*        /var/log/cyrus_imapd.log" >> /etc/rsyslog.d/cyrus.conf 
+RUN echo "auth.debug      /var/log/cyrus_auth.log" >> /etc/rsyslog.d/cyrus.conf 
+# avoid writing to kernel log
+RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
+# create user and group
 
-CMD /usr/sbin/cyrmaster
+RUN groupadd -fr mail
+RUN useradd -c "Cyrus IMAP Server" -d /var/lib/cyrus -g mail -s /bin/bash -r cyrus
+RUN usermod -aG ssl-cert cyrus
 
+# Authentication with SASL (Ubuntu uses saslauth group, Debian uses sasl group.)
+RUN groupadd -fr sasl
+
+RUN usermod -aG sasl cyrus
+ADD saslauthd /etc/default/saslauthd
+# cyrus file storage
+RUN mkdir -p /var/lib/cyrus /var/spool/cyrus /run/cyrus
+RUN chown -R cyrus:mail /var/lib/cyrus /var/spool/cyrus /run/cyrus
+RUN chmod 750 /var/lib/cyrus /var/spool/cyrus /run/cyrus
+
+RUN sudo -u cyrus ./tools/mkimap
+
+## expose ports
+EXPOSE 143
+EXPOSE 80
+
+## Launch cyrus
+ADD run.sh run.sh
+RUN chmod +x run.sh
+CMD sh run.sh

--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ curl -X POST \
     }' \
     http://localhost:1080/jmap/
 ```
+
+And to get the JMAP session
+
+```
+curl -X GET \
+    -H "Content-Type: application/json" \
+    --user bob:bob \
+    http://localhost:1080/jmap/
+```

--- a/cyrus.conf
+++ b/cyrus.conf
@@ -1,90 +1,57 @@
-# Debian defaults for Cyrus IMAP server/cluster implementation
-# see cyrus.conf(5) for more information
-#
-# All the tcp services are tcpd-wrapped. see hosts_access(5)
+# standard standalone server implementation
 
 START {
-	# do not delete this entry!
-	recover		cmd="/usr/sbin/cyrus ctl_cyrusdb -r"
-  
-	# this is only necessary if idlemethod is set to "idled" in imapd.conf
-	#idled		cmd="idled"
-
-	# this is useful on backend nodes of a Murder cluster
-	# it causes the backend to syncronize its mailbox list with
-	# the mupdate master upon startup
-	#mupdatepush   cmd="/usr/sbin/cyrus ctl_mboxlist -m"
-
-	# this is recommended if using duplicate delivery suppression
-	delprune	cmd="/usr/sbin/cyrus expire -E 3"
-	# this is recommended if caching TLS sessions
-	tlsprune	cmd="/usr/sbin/cyrus tls_prune"
+  # do not delete this entry!
+  recover       cmd="ctl_cyrusdb -r"
 }
 
-# UNIX sockets start with a slash and are absolute paths
-# you can use a maxchild=# to limit the maximum number of forks of a service
-# you can use babysit=true and maxforkrate=# to keep tight tabs on the service
-# most services also accept -U (limit number of reuses) and -T (timeout)
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
-	# --- Normal cyrus spool, or Murder backends ---
-	# add or remove based on preferences
-	imap		cmd="imapd -U 30" listen="imap" prefork=0 maxchild=100
-	#imaps		cmd="imapd -s -U 30" listen="imaps" prefork=0 maxchild=100
-	#pop3		cmd="pop3d -U 30" listen="pop3" prefork=0 maxchild=50
-	#pop3s		cmd="pop3d -s -U 30" listen="pop3s" prefork=0 maxchild=50
-	#nntp		cmd="nntpd -U 30" listen="nntp" prefork=0 maxchild=100
-	#nntps		cmd="nntpd -s -U 30" listen="nntps" prefork=0 maxchild=100
-	#http		cmd="httpd -U 30" listen="8008" prefork=0 maxchild=100
-	#https		cmd="httpd -s -U 30" listen="8443" prefork=0 maxchild=100
+  # add or remove based on preferences
+  imap          cmd="imapd" listen="imap" prefork=0
+  imaps         cmd="imapd -s" listen="imaps" prefork=0
+  pop3          cmd="pop3d" listen="pop3" prefork=0
+  pop3s         cmd="pop3d -s" listen="pop3s" prefork=0
+  sieve         cmd="timsieved" listen="sieve" prefork=0
 
+  # these are only necessary if receiving/exporting usenet via NNTP
+#  nntp          cmd="nntpd" listen="nntp" prefork=0
+#  nntps         cmd="nntpd -s" listen="nntps" prefork=0
 
-	# At least one form of LMTP is required for delivery
-	# (you must keep the Unix socket name in sync with imap.conf)
-	#lmtp		cmd="lmtpd" listen="localhost:lmtp" prefork=0 maxchild=20
-	lmtpunix	cmd="lmtpd" listen="/var/run/cyrus/socket/lmtp" prefork=0 maxchild=20
-	# ----------------------------------------------
+  # these are only necessary if using HTTP for CalDAV, CardDAV, or RSS
+  http          cmd="httpd" listen="http" prefork=0
+  https         cmd="httpd -s" listen="https" prefork=0
 
-	# useful if you need to give users remote access to sieve
-	# by default, we limit this to localhost in Debian
-  	sieve		cmd="timsieved" listen="localhost:sieve" prefork=0 maxchild=100
+  # at least one LMTP is required for delivery
+#  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
+  lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
-	# this one is needed for the notification services
-	notify		cmd="notifyd" listen="/var/run/cyrus/socket/notify" proto="udp" prefork=1
+  # this is requied if using socketmap
+#  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=0
 
-	# --- Murder frontends -------------------------
-	# enable these and disable the matching services above, 
-	# except for sieve (which deals automatically with Murder)
-
-	# mupdate database service - must prefork at least 1
-	# (mupdate slaves)
-	#mupdate       cmd="mupdate" listen=3905 prefork=1
-	# (mupdate master, only one in the entire cluster)
-	#mupdate       cmd="mupdate -m" listen=3905 prefork=1
-
-	# proxies that will connect to the backends
-	#imap		cmd="proxyd" listen="imap" prefork=0 maxchild=100
-	#imaps		cmd="proxyd -s" listen="imaps" prefork=0 maxchild=100
-	#pop3		cmd="pop3proxyd" listen="pop3" prefork=0 maxchild=50
-	#pop3s		cmd="pop3proxyd -s" listen="pop3s" prefork=0 maxchild=50
-	#lmtp		cmd="lmtpproxyd" listen="lmtp" prefork=1 maxchild=20
-	# ----------------------------------------------
+  # this is required if using notifications
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {
-	# this is required
-	checkpoint	cmd="/usr/sbin/cyrus ctl_cyrusdb -c" period=30
+  # this is required
+  checkpoint    cmd="ctl_cyrusdb -c" period=30
 
-	# this is only necessary if using duplicate delivery suppression
-	delprune	cmd="/usr/sbin/cyrus expire -E 3" at=0401
+  # this is only necessary if using duplicate delivery suppression,
+  # Sieve or NNTP
+  delprune      cmd="cyr_expire -E 3" at=0400
 
-	# this is only necessary if caching TLS sessions
-	tlsprune	cmd="/usr/sbin/cyrus tls_prune" at=0401
-	
-	# indexing of mailboxes for server side fulltext searches
+  # Expire data older than 28 days.
+  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
+  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
 
-	# reindex changed mailboxes (fulltext) approximately every other hour
-	#squatter_1	cmd="/usr/bin/nice -n 19 /usr/sbin/cyrus squatter -s" period=120
+  # this is only necessary if caching TLS sessions
+  tlsprune      cmd="tls_prune" at=0400
+}
 
-	# reindex all mailboxes (fulltext) daily
-	#squatter_a	cmd="/usr/sbin/cyrus squatter" at=0517
+DAEMON {
+  # this is only necessary if using idled for IMAP IDLE
+#  idled         cmd="idled"
+  # run a rolling squatter (needed by xapian)
+  squatter cmd="squatter -R"
 }

--- a/imapd.conf
+++ b/imapd.conf
@@ -1,5 +1,13 @@
-# Debian Cyrus imapd.conf
+# Suggested minimal imapd.conf
 # See imapd.conf(5) for more information and more options
+
+# Space-separated users who have admin rights for all services.
+# NB: THIS MUST BE CONFIGURED
+admins: cyrus
+
+###################################################################
+## File, socket and DB location settings.
+###################################################################
 
 # Configuration directory
 configdirectory: /var/lib/cyrus
@@ -8,310 +16,120 @@ configdirectory: /var/lib/cyrus
 proc_path: /run/cyrus/proc
 mboxname_lockpath: /run/cyrus/lock
 
+# Locations for DB files
+# The following DB are recreated upon initialization, so should live in
+# ephemeral storage for best performance.
+duplicate_db_path: /run/cyrus/deliver.db
+ptscache_db_path:  /run/cyrus/ptscache.db
+statuscache_db_path: /run/cyrus/statuscache.db
+tls_sessions_db_path: /run/cyrus/tls_sessions.db
+
 # Which partition to use for default mailboxes
-defaultpartition: default
+defaultpartition: base
 partition-default: /var/spool/cyrus/mail
 
-# News setup
-partition-news: /var/spool/cyrus/news
-newsspool: /var/spool/news
+# If sieveusehomedir is false (the default), this directory is searched
+# for Sieve scripts.
+sievedir: /var/spool/sieve
 
-servername: test
+###################################################################
+## Important: KEEP THESE IN SYNC WITH cyrus.conf
+###################################################################
 
-# Alternate namespace
-# If enabled, activate the alternate namespace as documented in
-# /usr/share/doc/cyrus-doc-2.4/html/altnamespace.html, where an user's
-# subfolders are in the same level as the INBOX
-# See also userprefix and sharedprefix on imapd.conf(5)
-altnamespace: no
+lmtpsocket: /run/cyrus/socket/lmtp
+idlesocket: /run/cyrus/socket/idle
+notifysocket: /run/cyrus/socket/notify
 
-# UNIX Hierarchy Convention
-# Set to yes, and cyrus will accept dots in names, and use the forward
-# slash "/" to delimit levels of the hierarchy. This is done by converting
-# internally all dots to "^", and all "/" to dots. So the "rabbit.holes"
-# mailbox of user "helmer.fudd" is stored in "user.elmer^fud.rabbit^holes"
-unixhierarchysep: no
+# Syslog prefix. Defaults to cyrus (so logging is done as cyrus/imap
+# etc.)
+syslog_prefix: cyrus
 
-# Rejecting illegal characters in headers
-# Headers of RFC2882 messages must not have characters with the 8th bit
-# set. However, too many badly-written MUAs generate this, including most
-# spamware. Enable this to reject such messages.
-#reject8bit: yes
+###################################################################
+## Server behaviour settings
+###################################################################
 
-# Munging illegal characters in headers
-# Headers of RFC2882 messages must not have characters with the 8th bit
-# set. However, too many badly-written MUAs generate this, including most
-# spamware. If you kept reject8bit disabled, you can choose to leave the
-# crappage untouched by disabling this (if you don't care that IMAP SEARCH
-# won't work right anymore.
-#munge8bit: no
+# Space-separated list of HTTP modules that will be enabled in
+# httpd(8).  This option has no effect on modules that are disabled at
+# compile time due to missing dependencies (e.g. libical).
+#
+# Allowed values: caldav, carddav, domainkey, ischedule, rss
+httpmodules: jmap
 
-# Forcing recipient user to lowercase
-# Cyrus IMAPD is case-sensitive.  If all your mail users are in lowercase, it is
-# probably a very good idea to set lmtp_downcase_rcpt to true.  This is set by 
-# default, per RFC2821. This was not set by default in debian versions up to
-# and including 2.2.12-4.
-lmtp_downcase_rcpt: yes
+# If enabled, the partitions will also be hashed, in addition to the
+# hashing done on configuration directories. This is recommended if one
+# partition has a very bushy mailbox tree.
+hashimapspool: true
 
-# Uncomment the following and add the space-separated users who 
-# have admin rights for all services.
-admins: cyrus
+# Enable virtual domains
+# and set default domain to localhost
+virtdomains: yes
+defaultdomain: test
 
-# Space-separated list of users that have lmtp "admin" status (i.e. that
-# can deliver email through TCP/IP lmtp). If specified, this parameter
-# overrides the "admins" parameter above
-#lmtp_admins: postman
-
-# Space-separated list of users that have mupdate "admin" status, in
-# addition to those in the admins: entry above. Note that mupdate slaves and 
-# backends in a Murder cluster need to autenticate against the mupdate master
-# as admin users.
-#mupdate_admins: mupdateman
-
-# Space-separated list of users that have imapd "admin" status, in
-# addition to those in the admins: entry above
-imap_admins: cyrus
-
-# Space-separated list of users that have sieve "admin" status, in
-# addition to those in the admins: entry above
-#sieve_admins: cyrus
-
-# List of users and groups that are allowed to proxy for other users,
-# seperated by spaces.  Any user listed in this will be allowed to login
-# for any other user.  Like "admins:" above, you can have imap_proxyservers
-# and sieve_proxyservers.
-#proxyservers: cyrus
-
-# No anonymous logins
-allowanonymouslogin: no
+###################################################################
+## User experience settings
+###################################################################
 
 # Minimum time between POP mail fetches in minutes
 popminpoll: 1
 
-# If nonzero, normal users may create their own IMAP accounts by creating
-# the mailbox INBOX.  The user's quota is set to the value if it is positive,
-# otherwise the user has unlimited quota.
-autocreatequota: 0
-
-# umask used by Cyrus programs
-umask: 077
-
-# Sendmail binary location
-# DUE TO A BUG, Cyrus sends CRLF EOLs to this program. This breaks Exim 3. 
-# For now, to work around the bug, set this to a wrapper that calls 
-# /usr/sbin/sendmail -dropcr instead if you use Exim 3.
-#sendmail: /usr/sbin/sendmail
-
-# If enabled, cyrdeliver will look for Sieve scripts in user's home
-# directories: ~user/.sieve.
-sieveusehomedir: false
-
-# If sieveusehomedir is false, this directory is searched for Sieve scripts.
-sievedir: /var/spool/sieve
-
-# notifyd(8) method to use for "MAIL" notifications.  If not set, "MAIL"
-# notifications are disabled.  Valid methods are: null, log, zephyr
-#mailnotifier: zephyr
-
-# notifyd(8) method to use for "SIEVE" notifications.  If not set, "SIEVE"
-# notifications are disabled.  This method is only used when no method is
-# specified in the script.  Valid methods are null, log, zephyr, mailto
-#sievenotifier: zephyr
-
-# If enabled, the partitions will also be hashed, in addition to the hashing
-# done on configuration directories. This is recommended if one partition has a
-# very bushy mailbox tree.
-hashimapspool: true
+###################################################################
+## User Authentication settings
+###################################################################
 
 # Allow plaintext logins by default (SASL PLAIN)
 allowplaintext: yes
 
-# Force PLAIN/LOGIN authentication only
-# (you need to uncomment this if you are not using an auxprop-based SASL
-# mechanism.  saslauthd users, that means you!). And pay attention to
-# sasl_minimum_layer and allowapop below, too.
-sasl_mech_list: PLAIN
+###################################################################
+## SASL library options (these are handled directly by the SASL
+## libraries, refer to SASL documentation for an up-to-date list of
+## these)
+###################################################################
 
-# Allow use of the POP3 APOP authentication command.
-# Note that this command requires that the plaintext passwords are 
-# available in a SASL auxprop backend (eg. sasldb), and that the system
-# can provide enough entropy (eg. from /dev/urandom) to create a challenge
-# in the banner.
-#allowapop: no
-
-# The minimum SSF that the server will allow a client to negotiate. A
-# value of 1 requires integrity protection; any higher value requires some
-# amount of encryption.
-sasl_minimum_layer: 0
-
-# The maximum SSF that the server will allow a client to negotiate. A
-# value of 1 requires integrity protection; any higher value requires some
-# amount of encryption.
-#sasl_maximum_layer: 256
-
-# List of remote realms whose users may log in using cross-realm
-# authentications. Seperate each realm name by a space. A cross-realm
-# identity is considered any identity returned by SASL with an "@" in it.
-# NOTE: To support multiple virtual domains on the same interface/IP,
-# you need to list them all as loginreals. If you don't list them here,
-# (most of) your users probably won't be able to log in.
-#loginrealms: example.com
-
-# Enable virtual domain support.  If enabled, the user's domain will
-# be determined by splitting a fully qualified userid at the last '@'
-# or '%' symbol.  If the userid is unqualified, and the virtdomains
-# option is set to "on", then the domain will be determined by doing
-# a reverse lookup on the IP address of the incoming network
-# interface, otherwise the user is assumed to be in the default
-# domain (if set).
-virtdomains: userid
-
-# The default domain for virtual domain support
-# If the domain of a user can't be taken from its login and it can't
-# be determined by doing a reverse lookup on the interface IP, this
-# domain is used.
-defaultdomain: test
-
-#
-# SASL library options (these are handled directly by the SASL libraries,
-# refer to SASL documentation for an up-to-date list of these)
-#
-
-# The mechanism(s) used by the server to verify plaintext passwords. Possible
-# values are "saslauthd", "auxprop", "pwcheck" and "alwaystrue".  They
-# are tried in order, you can specify more than one, separated by spaces.
-#
-# Do note that, since sasl will be run as user cyrus, you may have a lot of
-# trouble to set this up right.
+# The mechanism(s) used by the server to verify plaintext passwords.
+# Possible values are "saslauthd", "auxprop", "pwcheck" and
+# "alwaystrue".  They are tried in order, you can specify more than one,
+# separated by spaces.
 sasl_pwcheck_method: auxprop
 
-# What auxpropd plugins to load, if using sasl_pwcheck_method: auxprop
-# by default, all plugins are tried (which is probably NOT what you want).
-#sasl_auxprop_plugin: sasldb
-
-# If enabled, the SASL library will automatically create authentication secrets
-# when given a plaintext password. Refer to SASL documentation 
+# If enabled, the SASL library will automatically create authentication
+# secrets when given a plaintext password. Refer to SASL documentation
 sasl_auto_transition: no
 
-#
-# SSL/TLS Options
-#
+###################################################################
+## SSL/TLS Options
+###################################################################
 
-# File containing the global certificate used for ALL services (imap, pop3,
-# lmtp, sieve)
-#tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
+# File containing the global certificate used for ALL services (imap,
+# pop3, lmtp, sieve)
+#tls_server_cert: /etc/ssl/certs/ssl-cert-snakeoil.pem
 
-# File containing the private key belonging to the global server certificate.
-#tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+# File containing the private key belonging to the global server
+# certificate.
+#tls_server_key: /etc/ssl/private/ssl-cert-snakeoil.key
 
-# File containing the certificate used for imap. If not specified, the global
-# certificate is used.  A value of "disabled" will disable SSL/TLS for imap.
-#imap_tls_cert_file: /etc/ssl/certs/cyrus-imap.pem
-
-# File containing the private key belonging to the imap-specific server
-# certificate.  If not specified, the global private key is used.  A value of
-# "disabled" will disable SSL/TLS for imap.
-#imap_tls_key_file: /etc/ssl/private/cyrus-imap.key
-
-# File containing the certificate used for pop3. If not specified, the global
-# certificate is used.  A value of "disabled" will disable SSL/TLS for pop3.
-#pop3_tls_cert_file: /etc/ssl/certs/cyrus-pop3.pem
-
-# File containing the private key belonging to the pop3-specific server
-# certificate.  If not specified, the global private key is used.  A value of
-# "disabled" will disable SSL/TLS for pop3.
-#pop3_tls_key_file: /etc/ssl/private/cyrus-pop3.key
-
-# File containing the certificate used for lmtp. If not specified, the global
-# certificate is used.  A value of "disabled" will disable SSL/TLS for lmtp.
-#lmtp_tls_cert_file: /etc/ssl/certs/cyrus-lmtp.pem
-
-# File containing the private key belonging to the lmtp-specific server
-# certificate.  If not specified, the global private key is used.  A value of
-# "disabled" will disable SSL/TLS for lmtp.
-#lmtp_tls_key_file: /etc/ssl/private/cyrus-lmtp.key
-
-# File containing the certificate used for sieve. If not specified, the global
-# certificate is used.  A value of "disabled" will disable SSL/TLS for sieve.
-#sieve_tls_cert_file: /etc/ssl/certs/cyrus-sieve.pem
-
-# File containing the private key belonging to the sieve-specific server
-# certificate.  If not specified, the global private key is used.  A value of
-# "disabled" will disable SSL/TLS for sieve.
-#sieve_tls_key_file: /etc/ssl/private/cyrus-sieve.key
 
 # File containing one or more Certificate Authority (CA) certificates.
-#tls_ca_file: /etc/ssl/certs/cyrus-imapd-ca.pem
+#tls_client_ca_file: /etc/ssl/certs/cyrus-imapd-ca.pem
 
 # Path to directory with certificates of CAs.
-tls_ca_path: /etc/ssl/certs
+tls_client_ca_dir: /etc/ssl/certs
 
-# The length of time (in minutes) that a TLS session will be cached for later
-# reuse.  The maximum value is 1440 (24 hours), the default.  A value of 0 will
-# disable session caching.
+# The length of time (in minutes) that a TLS session will be cached for
+# later reuse.  The maximum value is 1440 (24 hours), the default.  A
+# value of 0 will disable session caching.
 tls_session_timeout: 1440
 
-# The list of SSL/TLS ciphers to allow, in decreasing order of precedence.  
-# The format of the string is described in ciphers(1).  The Debian default
-# selects TLSv1 high-security ciphers only, and removes all anonymous ciphers
-# from the list (because they provide no defense against man-in-the-middle
-# attacks).  It also orders the list so that stronger ciphers come first.
-tls_cipher_list: TLSv1+HIGH:!aNULL:@STRENGTH
 
-# Require a client certificate for ALL services (imap, pop3, lmtp, sieve).
-#tls_require_cert: false
-
-# Require a client certificate for imap ONLY.
-#imap_tls_require_cert: false
-
-# Require a client certificate for pop3 ONLY.
-#pop3_tls_require_cert: false
-
-# Require a client certificate for lmtp ONLY.
-#lmtp_tls_require_cert: false
-
-# Require a client certificate for sieve ONLY.
-#sieve_tls_require_cert: false
-
-#
-# Cyrus Murder cluster configuration
-#
-# Set the following options to the values needed for this server to
-# autenticate against the mupdate master server:
-# mupdate_server
-# mupdate_port
-# mupdate_username
-# mupdate_authname
-# mupdate_realm
-# mupdate_password
-# mupdate_retry_delay
-
-##
-## KEEP THESE IN SYNC WITH cyrus.conf
-##
-# Unix domain socket that lmtpd listens on.
-lmtpsocket: /var/run/cyrus/socket/lmtp
-
-# Unix domain socket that idled listens on.
-idlesocket: /var/run/cyrus/socket/idle
-
-# Unix domain socket that the new mail notification daemon listens on.
-notifysocket: /var/run/cyrus/socket/notify
-
-# Syslog prefix. Defaults to cyrus (so logging is done as cyrus/imap etc.)
-syslog_prefix: cyrus
-
-##
-## DEBUGGING
-##
-# Debugging hook. See /usr/share/doc/cyrus-common-2.4/README.Debian.debug
-# Keep the hook disabled when it is not in use
-#
-# gdb Back-traces
-#debug_command: /usr/bin/gdb -batch -cd=/tmp -x /usr/lib/cyrus/get-backtrace.gdb /usr/lib/cyrus/bin/%s %d >/tmp/gdb-backtrace.cyrus.%1$s.%2$d <&- 2>&1 &
-#
-# system-call traces
-#debug_command: /usr/bin/strace -tt -o /tmp/strace.cyrus.%s.%d -p %2$d <&- 2>&1 &
-#
-# library traces
-#debug_command: /usr/bin/ltrace -tt -n 2 -o /tmp/ltrace.cyrus.%s.%d -p %2$d <&- 2>&1 &
+##JMAP
+conversations: 1
+conversations_db: twoskip
+#needed by xapian
+sync_log: on
+sync_log_channels: squatter
+search_engine: xapian
+search_index_headers: no
+search_batchsize: 8192
+#defaultpartition: base
+defaultsearchtier: t1
+partition-base: /var/spool/cyrus
+t1searchpartition-base: /var/cyrus/search

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+/etc/init.d/rsyslog restart
+/etc/init.d/saslauthd start 
+# create some default user, cyrus is configured as admin in imapd.conf
+echo 'cyrus' | saslpasswd2 -p -c cyrus && testsaslauthd -u cyrus -p cyrus 
+echo 'bob' | saslpasswd2 -p -c bob && testsaslauthd -u bob -p bob 
+echo 'alice' | saslpasswd2 -p -c alice && testsaslauthd -u alice -p alice 
+
+./master/master

--- a/saslauthd
+++ b/saslauthd
@@ -1,0 +1,62 @@
+#
+# Settings for saslauthd daemon
+# Please read /usr/share/doc/sasl2-bin/README.Debian for details.
+#
+
+# Should saslauthd run automatically on startup? (default: no)
+START=yes
+
+# Description of this saslauthd instance. Recommended.
+# (suggestion: SASL Authentication Daemon)
+DESC="SASL Authentication Daemon"
+
+# Short name of this saslauthd instance. Strongly recommended.
+# (suggestion: saslauthd)
+NAME="saslauthd"
+
+# Which authentication mechanisms should saslauthd use? (default: pam)
+#
+# Available options in this Debian package:
+# getpwent  -- use the getpwent() library function
+# kerberos5 -- use Kerberos 5
+# pam       -- use PAM
+# rimap     -- use a remote IMAP server
+# shadow    -- use the local shadow password file
+# sasldb    -- use the local sasldb database file
+# ldap      -- use LDAP (configuration is in /etc/saslauthd.conf)
+#
+# Only one option may be used at a time. See the saslauthd man page
+# for more information.
+#
+# Example: MECHANISMS="pam"
+MECHANISMS="sasldb"
+
+# Additional options for this mechanism. (default: none)
+# See the saslauthd man page for information about mech-specific options.
+MECH_OPTIONS=""
+
+# How many saslauthd processes should we run? (default: 5)
+# A value of 0 will fork a new process for each connection.
+THREADS=5
+
+# Other options (default: -c -m /var/run/saslauthd)
+# Note: You MUST specify the -m option or saslauthd won't run!
+#
+# WARNING: DO NOT SPECIFY THE -d OPTION.
+# The -d option will cause saslauthd to run in the foreground instead of as
+# a daemon. This will PREVENT YOUR SYSTEM FROM BOOTING PROPERLY. If you wish
+# to run saslauthd in debug mode, please run it by hand to be safe.
+#
+# See /usr/share/doc/sasl2-bin/README.Debian for Debian-specific information.
+# See the saslauthd man page and the output of 'saslauthd -h' for general
+# information about these options.
+#
+# Example for chroot Postfix users: "-c -m /var/spool/postfix/var/run/saslauthd"
+# Example for non-chroot Postfix users: "-c -m /var/run/saslauthd"
+#
+# To know if your Postfix is running chroot, check /etc/postfix/master.cf.
+# If it has the line "smtp inet n - y - - smtpd" or "smtp inet n - - - - smtpd"
+# then your Postfix is running in a chroot.
+# If it has the line "smtp inet n - n - - smtpd" then your Postfix is NOT
+# running in a chroot.
+OPTIONS="-c -m /var/run/saslauthd"


### PR DESCRIPTION
This docker file build a cyrus server with jmap support.

Things that could be improved. 
If the users are created during the docker build phase. Cyrus can't access them.  So at the moment they are added in the run.sh.

If a user is added, before being able to execute any jmap request with him, we need to create a mailbox for him using IMAP